### PR TITLE
Add npm package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,10 @@
     "type": "git",
     "url": "git+https://github.com/wojtekmaj/react-hooks.git"
   },
+  "homepage": "https://github.com/wojtekmaj/react-hooks#readme",
+  "bugs": {
+    "url": "https://github.com/wojtekmaj/react-hooks/issues"
+  },
   "funding": "https://github.com/wojtekmaj/react-hooks?sponsor=1",
   "packageManager": "yarn@4.14.1"
 }


### PR DESCRIPTION
Adds npm package metadata that points users to the project README and issue tracker.

Changes:
- add homepage pointing to the GitHub README
- add bugs.url pointing to the GitHub issues page

Validation:
- node JSON metadata check passed
- git diff --check
- npm --cache ..\..\.npm-cache pack --dry-run --ignore-scripts --json