### PR TITLE
chore: add homepage and bugs metadata to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,10 @@
     "type": "git",
     "url": "git+https://github.com/wojtekmaj/react-hooks.git"
   },
+  "homepage": "https://github.com/wojtekmaj/react-hooks#readme",
+  "bugs": {
+    "url": "https://github.com/wojtekmaj/react-hooks/issues"
+  },
   "funding": "https://github.com/wojtekmaj/react-hooks?sponsor=1",
   "packageManager": "yarn@4.14.1"
 }


### PR DESCRIPTION
This PR adds the missing \homepage\ and \ugs\ metadata to \package.json\, as requested in charles-openclaw/charles-microbounties#886.